### PR TITLE
Add namespace and labels options to ingest log

### DIFF
--- a/src/secops/chronicle/client.py
+++ b/src/secops/chronicle/client.py
@@ -1149,7 +1149,9 @@ class ChronicleClient:
         log_entry_time: Optional[datetime] = None,
         collection_time: Optional[datetime] = None,
         forwarder_id: Optional[str] = None,
-        force_log_type: bool = False
+        force_log_type: bool = False,
+        namespace: Optional[str] = None,
+        labels: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Ingest a log into Chronicle.
         
@@ -1175,7 +1177,9 @@ class ChronicleClient:
             log_entry_time=log_entry_time,
             collection_time=collection_time,
             forwarder_id=forwarder_id,
-            force_log_type=force_log_type
+            force_log_type=force_log_type,
+            namespace=namespace,
+            labels=labels,
         )
 
     def get_or_create_forwarder(

--- a/src/secops/chronicle/log_ingest.py
+++ b/src/secops/chronicle/log_ingest.py
@@ -223,6 +223,8 @@ def ingest_log(
     log_message: Union[str, List[str]],
     log_entry_time: Optional[datetime] = None,
     collection_time: Optional[datetime] = None,
+    asset_namespace: Optional[str] = None,
+    ingestion_labels: Optional[Dict[str, str]] = None,
     forwarder_id: Optional[str] = None,
     force_log_type: bool = False
 ) -> Dict[str, Any]:
@@ -234,6 +236,8 @@ def ingest_log(
         log_message: Either a single log message string or a list of log message strings
         log_entry_time: The time the log entry was created (defaults to current time)
         collection_time: The time the log was collected (defaults to current time)
+        asset_namespace: The user-configured environment namespace to identify the data domain the logs originated from. This namespace will be used as a tag to identify the appropriate data domain for indexing and enrichment functionality.
+        ingestion_labels: The user-configured custom metadata labels.
         forwarder_id: ID of the forwarder to use (creates or uses default if None)
         force_log_type: Whether to force using the log type even if not in the valid list
         
@@ -293,12 +297,19 @@ def ingest_log(
         # Generate a unique ID for this log entry
         log_id = str(uuid.uuid4())
         
-        logs.append({
+        log_data = {
             "name": f"{client.instance_id}/logTypes/{log_type}/logs/{log_id}",
             "data": log_data,
             "log_entry_time": log_entry_time_str,
-            "collection_time": collection_time_str
-        })
+            "collection_time": collection_time_str,
+        }
+
+        if asset_namespace:
+            log_data["asset_namespace"] = asset_namespace
+        if ingestion_labels:
+            log_data["labels"] = {key: value for key, value in ingestion_labels.items()}
+
+        logs.append(log_data)
     
     # Construct the request payload
     payload = {

--- a/src/secops/chronicle/log_ingest.py
+++ b/src/secops/chronicle/log_ingest.py
@@ -223,8 +223,8 @@ def ingest_log(
     log_message: Union[str, List[str]],
     log_entry_time: Optional[datetime] = None,
     collection_time: Optional[datetime] = None,
-    asset_namespace: Optional[str] = None,
-    ingestion_labels: Optional[Dict[str, str]] = None,
+    namespace: Optional[str] = None,
+    labels: Optional[Dict[str, str]] = None,
     forwarder_id: Optional[str] = None,
     force_log_type: bool = False
 ) -> Dict[str, Any]:
@@ -294,20 +294,16 @@ def ingest_log(
         # Encode log message in base64
         log_data = base64.b64encode(msg.encode('utf-8')).decode('utf-8')
         
-        # Generate a unique ID for this log entry
-        log_id = str(uuid.uuid4())
-        
         log_data = {
-            "name": f"{client.instance_id}/logTypes/{log_type}/logs/{log_id}",
             "data": log_data,
             "log_entry_time": log_entry_time_str,
             "collection_time": collection_time_str,
         }
 
-        if asset_namespace:
-            log_data["asset_namespace"] = asset_namespace
-        if ingestion_labels:
-            log_data["labels"] = {key: value for key, value in ingestion_labels.items()}
+        if namespace:
+            log_data["asset_namespace"] = namespace
+        if labels:
+            log_data["labels"] = {key: value for key, value in labels.items()}
 
         logs.append(log_data)
     


### PR DESCRIPTION
`name` was also removed from the import log payload because this field is output only and is ignored by the API according to the [docs](https://cloud.google.com/chronicle/docs/reference/rest/v1alpha/projects.locations.instances.logTypes.logs#Log)