### PR TITLE
fix: Improve type hints and default values in secops library

### DIFF
--- a/src/secops/chronicle/alert.py
+++ b/src/secops/chronicle/alert.py
@@ -114,7 +114,7 @@ def get_alerts(
     # Initialize for polling
     complete = False
     attempts = 0
-    final_result = None
+    final_result = {}
     
     # Poll until we get a complete response or hit max attempts
     while not complete and attempts < max_attempts:

--- a/src/secops/chronicle/client.py
+++ b/src/secops/chronicle/client.py
@@ -501,7 +501,7 @@ class ChronicleClient:
         start_time: datetime,
         end_time: datetime,
         snapshot_query: str = "feedback_summary.status != \"CLOSED\"",
-        baseline_query: str = None,
+        baseline_query: Optional[str] = None,
         max_alerts: int = 1000,
         enable_cache: bool = True,
         max_attempts: int = 30,
@@ -619,8 +619,8 @@ class ChronicleClient:
         Returns:
             Tuple of (field_path, value_type)
         """
-        from secops.chronicle.entity import _detect_value_type
-        return _detect_value_type(value, value_type)
+        from secops.chronicle.entity import _detect_value_type_for_query
+        return _detect_value_type_for_query(value)
 
     # Rule Management methods
     

--- a/src/secops/chronicle/gemini.py
+++ b/src/secops/chronicle/gemini.py
@@ -134,7 +134,7 @@ class GeminiResponse:
         self.suggested_actions = suggested_actions or []
         self.references = references or []
         self.groundings = groundings or []
-        self.raw_response = raw_response
+        self.raw_response = raw_response or {}
     
     def __repr__(self) -> str:
         """Return string representation of the Gemini response.

--- a/src/secops/chronicle/models.py
+++ b/src/secops/chronicle/models.py
@@ -170,8 +170,8 @@ class Case:
         stage: str,
         priority: str,
         status: str,
-        soar_platform_info: SoarPlatformInfo = None,
-        alert_ids: list[str] = None
+        soar_platform_info: Optional[SoarPlatformInfo] = None,
+        alert_ids: Optional[list[str]] = None
     ):
         self.id = id
         self.display_name = display_name


### PR DESCRIPTION
This PR addresses several minor issues within the `secops` library, focusing on improved type handling, default values, and import consistency.

**Summary of Changes:**

*   **`alert.py`:**
    *   Changed `final_result` initialization from `None` to an empty dictionary `{}`. This provides a more consistent and usable default value for cases where results are accumulated.
*   **`client.py`:**
    *   Changed `baseline_query` type annotation from `str` to `Optional[str]`. This allows `baseline_query` to be explicitly set to `None` when no query is provided.
    *   Corrected the import and usage of the `_detect_value_type` function. The function was renamed to `_detect_value_type_for_query` in the `secops.chronicle.entity` module and the return value now only takes the value.
*   **`gemini.py`:**
    *   Modified `raw_response` initialization to assign an empty dictionary `{}` as a default value when `raw_response` is None.
*   **`models.py`:**
    *   Changed `soar_platform_info` and `alert_ids` type annotations from concrete types to `Optional[...]`. This allows these attributes to be explicitly set to `None` when they are not available.
