### PR TITLE
Fixed query param for get_alerts method as it's giving 400, FieldVoil…

### DIFF
--- a/src/secops/chronicle/alert.py
+++ b/src/secops/chronicle/alert.py
@@ -96,8 +96,8 @@ def get_alerts(
     
     # Build the request parameters
     params = {
-        "timeRange.startTime": start_time.isoformat(),
-        "timeRange.endTime": end_time.isoformat(),
+        "timeRange.startTime": f"{start_time.isoformat()}Z",
+        "timeRange.endTime": f"{end_time.isoformat()}Z",
         "snapshotQuery": snapshot_query,
     }
     


### PR DESCRIPTION
Hey there,
While using the SDK for the `get_alerts` functionality, I encountered an issue with the time format being sent in the request. The API endpoint expects the start_time and end_time values in ISO 8601 format with the 'Z' suffix indicating UTC time (e.g., 2023-05-13T15:30:00Z). However, the SDK generates these timestamps without appending the 'Z' suffix, which leads to invalid requests being made to the endpoint.


## Fix
Just append 'Z' in query_params.
Hope it works! ;)

## Please check the error output below:

```
secops.exceptions.APIError: Failed to get alerts: [{
  "error": {
    "code": 400,
    "message": "Invalid value at 'time_range.start_time' (type.googleapis.com/google.protobuf.Timestamp), Field 'start_time', Illegal timestamp format; timestamps must end with 'Z' or have a valid timezone offset.\nInvalid value at 
'time_range.end_time' (type.googleapis.com/google.protobuf.Timestamp), Field 'end_time', Illegal timestamp format; timestamps must end with 'Z' or have a valid timezone offset.",
    "status": "INVALID_ARGUMENT",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.BadRequest",
        "fieldViolations": [
          {
            "field": "time_range.start_time",
            "description": "Invalid value at 'time_range.start_time' (type.googleapis.com/google.protobuf.Timestamp), Field 'start_time', Illegal timestamp format; timestamps must end with 'Z' or have a valid timezone offset."      
          },
          {
            "field": "time_range.end_time",
            "description": "Invalid value at 'time_range.end_time' (type.googleapis.com/google.protobuf.Timestamp), 
Field 'end_time', Illegal timestamp format; timestamps must end with 'Z' or have a valid timezone offset."
          }
        ]
      }
    ]
  }
}
]
```