### PR TITLE
fix f-string related E999 SyntaxError issues found by flake8

### DIFF
--- a/src/secops/chronicle/rule.py
+++ b/src/secops/chronicle/rule.py
@@ -195,7 +195,7 @@ def enable_rule(client, rule_id: str, enabled: bool = True) -> Dict[str, Any]:
 
     if response.status_code != 200:
         raise APIError(
-            f"Failed to {"enable" if enabled else "disable"} "
+            f"Failed to {'enable' if enabled else 'disable'} "
             f"rule: {response.text}"
         )
 

--- a/src/secops/cli.py
+++ b/src/secops/cli.py
@@ -1354,8 +1354,8 @@ def handle_rule_validate_command(args, chronicle):
             print(f"Rule is invalid: {result.message}")
             if result.position:
                 print(
-                    f"Error at line {result.position["startLine"]}, "
-                    f"column {result.position["startColumn"]}"
+                    f"Error at line {result.position['startLine']}, "
+                    f"column {result.position['startColumn']}"
                 )
     except Exception as e:  # pylint: disable=broad-exception-caught
         print(f"Error: {e}", file=sys.stderr)
@@ -1655,10 +1655,8 @@ def handle_export_create_command(args, chronicle):
                     file=sys.stderr,
                 )
                 print("Available log types:", file=sys.stderr)
-                for lt in available_logs.get("available_log_types", [])[
-                    :5
-                ]:  # Show first 5
-                    print(f"  {lt.log_type.split("/")[-1]}", file=sys.stderr)
+                for lt in available_logs.get("available_log_types", [])[:5]:  # Show first 5
+                    print(f"  {lt.log_type.split('/')[-1]}", file=sys.stderr)
                 print("Attempting to create export anyway...", file=sys.stderr)
 
         # Proceed with export creation
@@ -1782,7 +1780,7 @@ def handle_gemini_command(args, chronicle):
     try:
         if args.opt_in:
             result = chronicle.opt_in_to_gemini()
-            print(f"Opt-in result: {"Success" if result else "Failed"}")
+            print(f"Opt-in result: {'Success' if result else 'Failed'}")
             if not result:
                 return
 
@@ -2331,7 +2329,7 @@ def main() -> None:
                 missing.append("project_id")
 
             print(
-                f"Error: Missing required configuration: {", ".join(missing)}",
+                f"Error: Missing required configuration: {', '.join(missing)}",
                 file=sys.stderr,
             )
             print("\nPlease set up your configuration first:", file=sys.stderr)


### PR DESCRIPTION
This PR fixes issue #62 

This pull request focuses on improving string formatting consistency across the codebase by replacing double quotes inside f-strings with single quotes. These changes enhance readability and reduce potential issues with nested quotes. 

### String formatting improvements:

* [`src/secops/chronicle/rule.py`](diffhunk://#diff-99eb7df2a17d90bbb22b30b3c36a990997bef4116f594b9569cd4033cc283c13L198-R198): Replaced double quotes with single quotes inside the f-string in the `enable_rule` function to improve readability and consistency.

* `src/secops/cli.py`:
  - Updated the `handle_rule_validate_command` function to use single quotes for dictionary key access within f-strings.
  - Simplified the slicing and string splitting in the `handle_export_create_command` function by replacing double quotes with single quotes inside the f-string.
  - Adjusted the `handle_gemini_command` function to use single quotes for string literals inside the f-string.
  - Modified the `main` function to use single quotes for the join operation inside the f-string.