### PR TITLE
fix: f-string quote delimiter for pylint compliant with older python version

### DIFF
--- a/src/secops/chronicle/rule.py
+++ b/src/secops/chronicle/rule.py
@@ -195,7 +195,7 @@ def enable_rule(client, rule_id: str, enabled: bool = True) -> Dict[str, Any]:
 
     if response.status_code != 200:
         raise APIError(
-            f"Failed to {"enable" if enabled else "disable"} "
+            f'Failed to {"enable" if enabled else "disable"} '
             f"rule: {response.text}"
         )
 

--- a/src/secops/cli.py
+++ b/src/secops/cli.py
@@ -1354,8 +1354,8 @@ def handle_rule_validate_command(args, chronicle):
             print(f"Rule is invalid: {result.message}")
             if result.position:
                 print(
-                    f"Error at line {result.position["startLine"]}, "
-                    f"column {result.position["startColumn"]}"
+                    f'Error at line {result.position["startLine"]}, '
+                    f'column {result.position["startColumn"]}'
                 )
     except Exception as e:  # pylint: disable=broad-exception-caught
         print(f"Error: {e}", file=sys.stderr)
@@ -1658,7 +1658,7 @@ def handle_export_create_command(args, chronicle):
                 for lt in available_logs.get("available_log_types", [])[
                     :5
                 ]:  # Show first 5
-                    print(f"  {lt.log_type.split("/")[-1]}", file=sys.stderr)
+                    print(f'  {lt.log_type.split("/")[-1]}', file=sys.stderr)
                 print("Attempting to create export anyway...", file=sys.stderr)
 
         # Proceed with export creation
@@ -1782,7 +1782,7 @@ def handle_gemini_command(args, chronicle):
     try:
         if args.opt_in:
             result = chronicle.opt_in_to_gemini()
-            print(f"Opt-in result: {"Success" if result else "Failed"}")
+            print(f'Opt-in result: {"Success" if result else "Failed"}')
             if not result:
                 return
 
@@ -2331,7 +2331,7 @@ def main() -> None:
                 missing.append("project_id")
 
             print(
-                f"Error: Missing required configuration: {", ".join(missing)}",
+                f'Error: Missing required configuration: {", ".join(missing)}',
                 file=sys.stderr,
             )
             print("\nPlease set up your configuration first:", file=sys.stderr)


### PR DESCRIPTION
Fixes https://github.com/google/secops-wrapper/issues/62

Update quote delimiter to be pylint compliant with python version < 3.12.

Update following with double quoted string literal inside f-string with single quote:
- `src/secops/chronicle/rule.py`
- `src/secops/cli.py`
