### PR TITLE
src/ Included to pyproject.toml  layout and also improve the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Google SecOps SDK for Python
 
+[![PyPI version](https://img.shields.io/pypi/v/secops.svg)](https://pypi.org/project/secops/)
+
 A Python SDK for interacting with Google Security Operations products, currently supporting Chronicle/SecOps SIEM.
 This wraps the API for common use cases, including UDM searches, entity lookups, IoCs, alert management, case management, and detection rule management.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ secops config set --customer-id "your-instance-id" --project-id "your-project-id
 secops search --query "metadata.event_type = \"NETWORK_CONNECTION\""
 ```
 
-For detailed CLI documentation and examples, see the [CLI Documentation](CLI.md).
+For detailed CLI documentation and examples, see the [CLI Documentation](https://github.com/google/secops-wrapper/blob/main/CLI.md).
+
 
 ## Authentication
 
@@ -149,7 +150,7 @@ chronicle = client.chronicle(
     region="us"                               # Chronicle API region 
 )
 ```
-[See available regions](regions.md)
+[See available regions](https://github.com/google/secops-wrapper/blob/main/regions.md)
 
 ### Log Ingestion
 
@@ -1765,4 +1766,4 @@ You can optionally provide a `preferred_entity_type` hint to `summarize_entity` 
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the LICENSE file for details.
+This project is licensed under the Apache License 2.0 - [see the LICENSE file for details.](https://github.com/google/secops-wrapper/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Google SecOps SDK for Python
 
-[![LICENSE](https://img.shields.io/badge/License-Apache%202.0-blue?logo=apache)](https://opensource.org/licenses/Apache-2.0)
 [![PyPI version](https://img.shields.io/pypi/v/secops.svg)](https://pypi.org/project/secops/)
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Google SecOps SDK for Python
 
+[![LICENSE](https://img.shields.io/badge/License-Apache%202.0-blue?logo=apache)](https://opensource.org/licenses/Apache-2.0)
 [![PyPI version](https://img.shields.io/pypi/v/secops.svg)](https://pypi.org/project/secops/)
+
 
 A Python SDK for interacting with Google Security Operations products, currently supporting Chronicle/SecOps SIEM.
 This wraps the API for common use cases, including UDM searches, entity lookups, IoCs, alert management, case management, and detection rule management.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,4 +57,7 @@ markers = [
 ]
 
 [project.scripts]
-secops = "secops.cli:main" 
+secops = "secops.cli:main"
+
+[tool.hatch.build]
+sources = ["src"]


### PR DESCRIPTION
This pull request adds  src/ to pyproject.toml layout for better packaging and import isolation. Also improved the README.md added https://github.com/google/secops-wrapper/blob/main/
Fixes : #70 #69 

Changes included:
Added [tool.hatch.build] section in pyproject.toml to support the src/ layout
Added https://github.com/google/secops-wrapper/blob/main/*.md to README.md

Also added the PyPi version and Licence badge to README.md