### PR TITLE
feat: added support for generating udm key/value mapping for row log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2025-08-05
+### Added
+- Generate UDM key/value mapping from row log
+
 ## [0.10.0] - 2025-07-31
 ### Added
 - Parser Extension management functionalities

--- a/CLI.md
+++ b/CLI.md
@@ -196,6 +196,19 @@ secops log types --search "windows"
 
 > **Note:** Chronicle uses parsers to process and normalize raw log data into UDM format. If you're ingesting logs for a custom format, you may need to create or configure parsers. See the [Parser Management](#parser-management) section for details on managing parsers.
 
+
+### Generate UDM Key/Value Mapping
+
+Generate UDM key/value mapping for provided row log
+
+```bash
+secops log generate-udm-mapping \ 
+--log-format "JSON" \
+--log '{"events":[{"id":"123","user":"test_user","source_ip":"192.168.1.10"}]}' \
+--use-array-bracket-notation "true" \
+--compress-array-fields "false"
+```
+
 ### Parser Management
 
 Parsers in Chronicle are used to process and normalize raw log data into UDM (Unified Data Model) format. The CLI provides comprehensive parser management capabilities.

--- a/README.md
+++ b/README.md
@@ -803,6 +803,26 @@ case = cases.get_case("case-id-1")
 
 > **Note**: The case management API uses the `legacy:legacyBatchGetCases` endpoint to retrieve multiple cases in a single request. You can retrieve up to 1000 cases in a single batch.
 
+### Generating UDM Key/Value Mapping
+Chronicle provides a feature to generate UDM key-value mapping for a given row log.
+
+```python
+mapping = chronicle.generate_udm_key_value_mappings(
+    log_format="JSON",
+    log='{"events":[{"id":"123","user":"test_user","source_ip":"192.168.1.10"}]}',
+    use_array_bracket_notation=True,
+    compress_array_fields=False,
+)
+
+print(f"Generated UDM key/value mapping: {mapping}")
+```
+
+```python
+# Generate UDM key-value mapping
+udm_mapping = chronicle.generate_udm_mapping(log_type="WINDOWS_AD")
+print(udm_mapping)
+```
+
 ## Parser Management
 
 Chronicle parsers are used to process and normalize raw log data into Chronicle's Unified Data Model (UDM) format. Parsers transform various log formats (JSON, XML, CEF, etc.) into a standardized structure that enables consistent querying and analysis across different data sources.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "secops"
-version = "0.10.0"
+version = "0.11.0"
 description = "Python SDK for wrapping the Google SecOps API for common use cases"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/secops/chronicle/__init__.py
+++ b/src/secops/chronicle/__init__.py
@@ -113,6 +113,10 @@ from secops.chronicle.search import search_udm
 from secops.chronicle.stats import get_stats
 from secops.chronicle.udm_search import fetch_udm_search_csv
 from secops.chronicle.validate import validate_query
+from secops.chronicle.udm_mapping import (
+    generate_udm_key_value_mappings,
+    RowLogFormat,
+)
 
 __all__ = [
     # Client
@@ -172,6 +176,8 @@ __all__ = [
     "compute_rule_exclusion_activity",
     "get_rule_exclusion_deployment",
     "update_rule_exclusion_deployment",
+    # UDM Mapping
+    "generate_udm_key_value_mappings",
     # Rule alert operations
     "get_alert",
     "update_alert",
@@ -206,6 +212,7 @@ __all__ = [
     "SuggestedAction",
     "NavigationAction",
     "UpdateRuleDeployment",
+    "RowLogFormat",
     # Data Table and Reference List
     "DataTableColumnType",
     "ReferenceListSyntaxType",

--- a/src/secops/chronicle/client.py
+++ b/src/secops/chronicle/client.py
@@ -155,8 +155,8 @@ from secops.chronicle.rule_retrohunt import (
 )
 from secops.chronicle.rule_retrohunt import get_retrohunt as _get_retrohunt
 from secops.chronicle.rule_set import (
-    batch_update_curated_rule_set_deployments as _batch_update_curated_rule_set_deployments,
-)  # pylint: disable=line-too-long
+    batch_update_curated_rule_set_deployments as _batch_update_curated_rule_set_deployments,  # pylint: disable=line-too-long
+)
 from secops.chronicle.rule_validation import validate_rule as _validate_rule
 from secops.chronicle.search import search_udm as _search_udm
 from secops.chronicle.stats import get_stats as _get_stats
@@ -2283,10 +2283,7 @@ class ChronicleClient:
         use_array_bracket_notation: Optional[bool] = None,
         compress_array_fields: Optional[bool] = None,
     ) -> Dict[str, Any]:
-        """Generate key-value mappings for a UDM field using Chronicle V1alpha API.
-
-        This function retrieves all unique values for the specified UDM field
-        and returns a dictionary mapping each value to its frequency.
+        """Generate UDM key-value mappings for provided row log
 
         Args:
             log_format: The format of the log (JSON, CSV, XML)

--- a/src/secops/chronicle/client.py
+++ b/src/secops/chronicle/client.py
@@ -78,6 +78,17 @@ from secops.chronicle.log_types import search_log_types as _search_log_types
 from secops.chronicle.models import CaseList, EntitySummary
 from secops.chronicle.nl_search import nl_search as _nl_search
 from secops.chronicle.nl_search import translate_nl_to_udm
+from secops.chronicle.parser import activate_parser as _activate_parser
+from secops.chronicle.parser import (
+    activate_release_candidate_parser as _activate_release_candidate_parser,
+)
+from secops.chronicle.parser import copy_parser as _copy_parser
+from secops.chronicle.parser import create_parser as _create_parser
+from secops.chronicle.parser import deactivate_parser as _deactivate_parser
+from secops.chronicle.parser import delete_parser as _delete_parser
+from secops.chronicle.parser import get_parser as _get_parser
+from secops.chronicle.parser import list_parsers as _list_parsers
+from secops.chronicle.parser import run_parser as _run_parser
 from secops.chronicle.reference_list import (
     ReferenceListSyntaxType,
     ReferenceListView,
@@ -114,48 +125,51 @@ from secops.chronicle.rule_alert import (
 from secops.chronicle.rule_alert import update_alert as _update_alert
 from secops.chronicle.rule_detection import list_detections as _list_detections
 from secops.chronicle.rule_detection import list_errors as _list_errors
+from secops.chronicle.rule_exclusion import (
+    RuleExclusionType,
+    UpdateRuleDeployment,
+)
+from secops.chronicle.rule_exclusion import (
+    compute_rule_exclusion_activity as _compute_rule_exclusion_activity,
+)
+from secops.chronicle.rule_exclusion import (
+    create_rule_exclusion as _create_rule_exclusion,
+)
+from secops.chronicle.rule_exclusion import (
+    get_rule_exclusion as _get_rule_exclusion,
+)
+from secops.chronicle.rule_exclusion import (
+    get_rule_exclusion_deployment as _get_rule_exclusion_deployment,
+)
+from secops.chronicle.rule_exclusion import (
+    list_rule_exclusions as _list_rule_exclusions,
+)
+from secops.chronicle.rule_exclusion import (
+    patch_rule_exclusion as _patch_rule_exclusion,
+)
+from secops.chronicle.rule_exclusion import (
+    update_rule_exclusion_deployment as _update_rule_exclusion_deployment,
+)
 from secops.chronicle.rule_retrohunt import (
     create_retrohunt as _create_retrohunt,
 )
 from secops.chronicle.rule_retrohunt import get_retrohunt as _get_retrohunt
 from secops.chronicle.rule_set import (
-    batch_update_curated_rule_set_deployments as _batch_update_curated_rule_set_deployments,  # pylint: disable=line-too-long
-)
+    batch_update_curated_rule_set_deployments as _batch_update_curated_rule_set_deployments,
+)  # pylint: disable=line-too-long
+from secops.chronicle.rule_validation import validate_rule as _validate_rule
 from secops.chronicle.search import search_udm as _search_udm
 from secops.chronicle.stats import get_stats as _get_stats
+from secops.chronicle.udm_mapping import RowLogFormat
+from secops.chronicle.udm_mapping import (
+    generate_udm_key_value_mappings as _generate_udm_key_value_mappings,
+)
 
 # Import functions from the new modules
 from secops.chronicle.udm_search import (
     fetch_udm_search_csv as _fetch_udm_search_csv,
 )
 from secops.chronicle.validate import validate_query as _validate_query
-
-from .parser import activate_parser as _activate_parser
-from .parser import (
-    activate_release_candidate_parser as _activate_release_candidate_parser,
-)
-from .parser import copy_parser as _copy_parser
-from .parser import create_parser as _create_parser
-from .parser import deactivate_parser as _deactivate_parser
-from .parser import delete_parser as _delete_parser
-from .parser import get_parser as _get_parser
-from .parser import list_parsers as _list_parsers
-from .parser import run_parser as _run_parser
-from .rule_exclusion import RuleExclusionType, UpdateRuleDeployment
-from .rule_exclusion import (
-    compute_rule_exclusion_activity as _compute_rule_exclusion_activity,
-)
-from .rule_exclusion import create_rule_exclusion as _create_rule_exclusion
-from .rule_exclusion import get_rule_exclusion as _get_rule_exclusion
-from .rule_exclusion import (
-    get_rule_exclusion_deployment as _get_rule_exclusion_deployment,
-)
-from .rule_exclusion import list_rule_exclusions as _list_rule_exclusions
-from .rule_exclusion import patch_rule_exclusion as _patch_rule_exclusion
-from .rule_exclusion import (
-    update_rule_exclusion_deployment as _update_rule_exclusion_deployment,
-)
-from .rule_validation import validate_rule as _validate_rule
 
 
 class ValueType(Enum):
@@ -2261,3 +2275,36 @@ class ChronicleClient:
             SecOpsError: If no description or entries are provided to be updated
         """
         return _update_reference_list(self, name, description, entries)
+
+    def generate_udm_key_value_mappings(
+        self,
+        log_format: str,
+        log: str,
+        use_array_bracket_notation: Optional[bool] = None,
+        compress_array_fields: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Generate key-value mappings for a UDM field using Chronicle V1alpha API.
+
+        This function retrieves all unique values for the specified UDM field
+        and returns a dictionary mapping each value to its frequency.
+
+        Args:
+            log_format: The format of the log (JSON, CSV, XML)
+            log: The log to retrieve unique values from
+            use_array_bracket_notation: Whether to use array bracket notation
+            compress_array_fields: Whether to compress array fields
+
+        Returns:
+            Dictionary containing the generated key-value mappings
+
+        Raises:
+            APIError: If the API request fails
+        """
+
+        return _generate_udm_key_value_mappings(
+            self,
+            RowLogFormat(log_format),
+            log,
+            use_array_bracket_notation,
+            compress_array_fields,
+        )

--- a/src/secops/chronicle/log_types.py
+++ b/src/secops/chronicle/log_types.py
@@ -14,9 +14,9 @@
 #
 """Chronicle log type utilities for raw log ingestion.
 
-This module provides functions to help users select the correct Chronicle 
-log type for raw log ingestion. It includes functionality to search for 
-log types, validate log types, and suggest appropriate log types based on 
+This module provides functions to help users select the correct Chronicle
+log type for raw log ingestion. It includes functionality to search for
+log types, validate log types, and suggest appropriate log types based on
 product or vendor.
 """
 

--- a/src/secops/chronicle/udm_mapping.py
+++ b/src/secops/chronicle/udm_mapping.py
@@ -1,0 +1,95 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""UDM key/value mapping functionality of Chronicle"""
+
+import base64
+import sys
+from typing import Any, Dict, Optional
+
+from secops.exceptions import APIError
+
+# Use built-in StrEnum if Python 3.11+, otherwise create a compatible version
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """String enum implementation for Python versions before 3.11."""
+
+        def __str__(self) -> str:
+            return self.value
+
+
+class RowLogFormat(StrEnum):
+    """Enum for log format specification."""
+
+    JSON = "JSON"
+    CSV = "CSV"
+    XML = "XML"
+    LOG_FORMAT_UNSPECIFIED = "LOG_FORMAT_UNSPECIFIED"
+
+
+def generate_udm_key_value_mappings(
+    client,
+    log_format: RowLogFormat,
+    log: str,
+    use_array_bracket_notation: Optional[bool] = None,
+    compress_array_fields: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Generate key-value mappings for a UDM field using Chronicle V1alpha API.
+
+    This function retrieves all unique values for the specified UDM field
+    across events within the given time range.
+
+    Args:
+        client: ChronicleClient instance
+        log_format: Log format (JSON, CSV, XML, or LOG_FORMAT_UNSPECIFIED)
+        log: Row log to generate key-value mapping
+        use_array_bracket_notation: Flag to format arrays as bracket notation.
+        compress_array_fields: Flag to compress array fields.
+
+    Returns:
+        Dict containing the generated key-value mapping
+
+    Raises:
+        APIError: If the API request fails
+    """
+    # Endpoint for UDM key-value mappings
+    url = f"{client.base_url}/{client.instance_id}:generateUdmKeyValueMappings"
+
+    encoded_log = None
+    try:
+        decoded = base64.b64decode(log)
+        decoded.decode("utf-8")  # Validate it's valid UTF-8 when decoded
+        encoded_log = log
+    except Exception:  # pylint: disable=broad-except
+        # If not base64 encoded, encode it
+        encoded_log = base64.b64encode(log.encode("utf-8")).decode("utf-8")
+
+    payload = {"log_format": log_format, "log": encoded_log}
+
+    if use_array_bracket_notation is not None:
+        payload["use_array_bracket_notation"] = use_array_bracket_notation
+    if compress_array_fields is not None:
+        payload["compress_array_fields"] = compress_array_fields
+
+    response = client.session.post(url, json=payload)
+
+    if response.status_code != 200:
+        raise APIError(f"Failed to generate key/value mapping: {response.text}")
+
+    # Return field mappings from parsed response
+    return response.json().get("fieldMappings")

--- a/tests/chronicle/test_integration.py
+++ b/tests/chronicle/test_integration.py
@@ -1514,3 +1514,65 @@ def test_chronicle_reference_lists_cidr():
         print(
             f"Note: CIDR reference list {rl_name} remains since reference list deletion is not supported by the API"
         )
+
+@pytest.mark.integration
+def test_chronicle_generate_udm_key_value_mapping():
+    """Test UDM key/value mapping functionality with real API."""
+    client = SecOpsClient(service_account_info=SERVICE_ACCOUNT_JSON)
+    chronicle = client.chronicle(**CHRONICLE_CONFIG)
+
+    # Sample Row JSON log
+    json_log = """
+    {
+        "events": [
+            {
+                "id": "123",
+                "user": "test_user",
+                "source_ip": "192.168.1.10",
+                "destination_url": "www.example.com",
+                "action_taken": "allowed",
+                "timestamp": 1588059648129
+            },
+            {
+                "id": "231",
+                "user": "test_user2",
+                "source_ip": "192.168.1.9",
+                "destination_url": "www.example2.com",
+                "action_taken": "allowed",
+                "timestamp": 1588059649129
+            }
+        ]
+    }
+    """
+
+    try:
+        print("\n>>> Testing Generating UDM key/value mapping")
+
+        json_mappings = chronicle.generate_udm_key_value_mappings(
+            log_format="JSON",
+            log=json_log,
+            use_array_bracket_notation=True,
+            compress_array_fields=False,
+        )
+        print(f"JSON mappings retrieved: {len(json_mappings)} fields")
+
+        # Verify we got expected mapping fields
+        assert isinstance(json_mappings, dict)
+        assert len(json_mappings) > 0
+
+        # Check for specific expected fields
+        expected_fields = [
+            "events[0].id",
+            "events[0].user",
+            "events[1].id",
+            "events[1].user",
+        ]
+
+        # Check for expected fields
+        assert all(field in json_mappings for field in expected_fields)
+
+        print("UDM key/value mapping successful")
+
+    except Exception as e:
+        print(f"Error during generate UDM key/value mapping test: {e}")
+        raise

--- a/tests/chronicle/test_rule_exclusion.py
+++ b/tests/chronicle/test_rule_exclusion.py
@@ -14,14 +14,13 @@
 #
 """Tests for the Rule Exclusion module."""
 
-import json
 import pytest
-from datetime import datetime, timezone
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 from secops.chronicle import rule_exclusion
 from secops.chronicle.client import ChronicleClient
-from secops.exceptions import APIError, SecOpsError
+from secops.exceptions import APIError
 
 
 @pytest.fixture

--- a/tests/chronicle/test_udm_mapping.py
+++ b/tests/chronicle/test_udm_mapping.py
@@ -1,0 +1,134 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for the UDM Key/Value Mapping module."""
+
+import base64
+from unittest.mock import Mock, patch
+
+import pytest
+
+from secops.chronicle.client import ChronicleClient
+from secops.chronicle.udm_mapping import (
+    RowLogFormat,
+    generate_udm_key_value_mappings,
+)
+from secops.exceptions import APIError
+
+
+@pytest.fixture
+def chronicle_client():
+    """Create a mock Chronicle client for testing."""
+    with patch("secops.auth.SecOpsAuth") as mock_auth:
+        mock_session = Mock()
+        mock_session.headers = {}
+        mock_auth.return_value.session = mock_session
+        return ChronicleClient(
+            customer_id="test-customer", project_id="test-project"
+        )
+
+
+@pytest.fixture
+def response_mock():
+    """Create a mock API response object."""
+    mock = Mock()
+    mock.status_code = 200
+    mock.json.return_value = {"testKey": "testValue"}
+    return mock
+
+
+def test_row_log_format_enum() -> None:
+    """Test RowLogFormat enum values and string representation."""
+    assert str(RowLogFormat.JSON) == "JSON"
+    assert str(RowLogFormat.CSV) == "CSV"
+    assert str(RowLogFormat.XML) == "XML"
+    assert str(RowLogFormat.LOG_FORMAT_UNSPECIFIED) == "LOG_FORMAT_UNSPECIFIED"
+
+
+def test_generate_udm_key_value_mappings_success(
+    chronicle_client, response_mock
+):
+    """Test generate_udm_key_value_mappings with success response."""
+
+    response_mock.json.return_value = {
+        "fieldMappings": {
+            "event.id": "123",
+            "event.user": "test_user",
+            "event.action": "allowed",
+        }
+    }
+    chronicle_client.session.post.return_value = response_mock
+
+    # Test input
+    test_log = '{"event":{"id":"123","user":"test_user","action":"allowed"}}'
+
+    result = generate_udm_key_value_mappings(
+        chronicle_client,
+        RowLogFormat.JSON,
+        test_log,
+        use_array_bracket_notation=True,
+        compress_array_fields=False,
+    )
+
+    # Verify API call
+    expected_url = (
+        f"{chronicle_client.base_url}/{chronicle_client.instance_id}"
+        ":generateUdmKeyValueMappings"
+    )
+    chronicle_client.session.post.assert_called_once()
+    args, kwargs = chronicle_client.session.post.call_args
+
+    # Check URL and payload structure
+    assert args[0] == expected_url
+    # Verify result
+    assert result == {
+        "event.id": "123",
+        "event.user": "test_user",
+        "event.action": "allowed",
+    }
+
+
+def test_generate_udm_key_value_mappings_already_encoded(
+    chronicle_client, response_mock
+):
+    """Test UDM mapping with already base64 encoded log."""
+    response_mock.json.return_value = {
+        "fieldMappings": {"test.field": "test_value"}
+    }
+    chronicle_client.session.post.return_value = response_mock
+
+    # Create a base64 encoded log
+    raw_log = '{"test":{"field":"test_value"}}'
+    encoded_log = base64.b64encode(raw_log.encode("utf-8")).decode("utf-8")
+
+    result = generate_udm_key_value_mappings(
+        chronicle_client, RowLogFormat.JSON, encoded_log
+    )
+
+    # Assert log wasn't double-encoded
+    _, kwargs = chronicle_client.session.post.call_args
+    assert kwargs["json"]["log"] == encoded_log
+    assert result == {"test.field": "test_value"}
+
+
+def test_generate_udm_key_value_mappings_error(chronicle_client, response_mock):
+    """Test generate_udm_key_value_mappings function with error response."""
+    response_mock.status_code = 400
+    response_mock.text = "Bad Request"
+    chronicle_client.session.post.return_value = response_mock
+
+    with pytest.raises(APIError, match="Failed to generate key/value mapping"):
+        generate_udm_key_value_mappings(
+            chronicle_client, RowLogFormat.JSON, "test"
+        )

--- a/tests/cli/test_rule_exclusion_integration.py
+++ b/tests/cli/test_rule_exclusion_integration.py
@@ -70,7 +70,7 @@ def test_cli_rule_exclusion_lifecycle(cli_env, common_args):
         print(f"Created rule exclusion with ID: {exclusion_id}")
 
         # Wait briefly for the rule exclusion to be fully created
-        time.sleep(2)
+        time.sleep(5)
 
         # 2. Get the rule exclusion
         get_cmd = (


### PR DESCRIPTION
Added:
- Generating UDM key/value mapping for row logs 

API Endpoint reference: [generateUdmKeyValueMappings](https://cloud.google.com/chronicle/docs/reference/rest/v1alpha/projects.locations.instances/generateUdmKeyValueMappings)