### PR TITLE
patch: Dev base url to HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 - Dev Base URL with HTTPS
 
-
 ## [0.12.2] - 2025-08-13
 ### Updated
 - Reverted Base url to `https://{region}-chronicle.googleapis.com` for all requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.12.2] - 2025-08-12
+## [0.12.3] - 2025-08-13
+### Updated
+- Dev Base URL with HTTPS
+
+
+## [0.12.2] - 2025-08-13
 ### Updated
 - Reverted Base url to `https://{region}-chronicle.googleapis.com` for all requests
 - Dev Base URL to `http://autopush-chronicle.sandbox.googleapis.com`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "secops"
-version = "0.12.2"
+version = "0.12.3"
 description = "Python SDK for wrapping the Google SecOps API for common use cases"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/secops/chronicle/client.py
+++ b/src/secops/chronicle/client.py
@@ -319,10 +319,10 @@ class ChronicleClient:
             # Set up the base URL for dev/staging
             if region == "dev":
                 self.base_url = (
-                    "http://autopush-chronicle.sandbox.googleapis.com/v1alpha"
+                    "https://autopush-chronicle.sandbox.googleapis.com/v1alpha"
                 )
                 self.base_v1_url = (
-                    "http://autopush-chronicle.sandbox.googleapis.com/v1"
+                    "https://autopush-chronicle.sandbox.googleapis.com/v1"
                 )
             else:  # staging
                 self.base_url = (


### PR DESCRIPTION
Updated dev base url with HTTPS (i.e. `https://autopush-chronicle.sandbox.googleapis.com`)