### PR TITLE
integration_test.yml: fix CODEOWNERS authorization bypass

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -144,13 +144,36 @@ jobs:
                 }
               }
               
-              // Check if commenter is in CODEOWNERS
-              const isAuthorized = 
-                owners.has(commenter) || 
-                Array.from(owners).some(owner => 
-                  owner.includes('/') && 
-                  owner.startsWith(context.repo.owner + '/')
-                );
+              // A commenter is authorized if they are named directly in
+              // CODEOWNERS, or are an active member of a CODEOWNERS team in this
+              // org. The team check MUST verify the commenter's own membership:
+              // the previous code authorized every commenter whenever any
+              // "@org/team" entry was present, regardless of who commented, so a
+              // single team line in CODEOWNERS would let any fork PR author run
+              // this workflow.
+              let isAuthorized = owners.has(commenter);
+              if (!isAuthorized) {
+                for (const owner of owners) {
+                  const slash = owner.indexOf('/');
+                  if (slash < 0) continue;
+                  const org = owner.slice(0, slash);
+                  const team = owner.slice(slash + 1);
+                  if (org !== context.repo.owner) continue;
+                  try {
+                    const membership = await github.rest.teams.getMembershipForUserInOrg({
+                      org,
+                      team_slug: team,
+                      username: commenter,
+                    });
+                    if (membership.data && membership.data.state === 'active') {
+                      isAuthorized = true;
+                      break;
+                    }
+                  } catch (error) {
+                    // 404 (not a member) or missing org-read scope: stay unauthorized.
+                  }
+                }
+              }
               
               // Output authorization result as a simple string
               core.setOutput("authorized", isAuthorized ? "true" : "false");

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -115,7 +115,7 @@ jobs:
             // Verify this is a pull request comment
             if (!context.payload.issue.pull_request) {
               console.log('This comment is not on a pull request. Skipping.');
-              core.setOutput("is_authorized", "false");
+              core.setOutput("authorized", "false");
               return;
             }
             


### PR DESCRIPTION
### Problem

`.github/workflows/integration_test.yml` runs integration tests (which check out PR-supplied code and run `pip install -e ".[test]"` + `pytest` with the repository's Chronicle service-account secrets) when an authorized user comments `/run-integration-tests <sha>`. The authorization check is:

```js
const isAuthorized =
  owners.has(commenter) ||
  Array.from(owners).some(owner =>
    owner.includes('/') && owner.startsWith(context.repo.owner + '/'));
```

The second branch never references `commenter`. It returns `true` as soon as **any** `@<org>/<team>` entry exists in CODEOWNERS and starts with the repo owner. So the moment a single `@google/<team>` line is added to `.github/CODEOWNERS` (a routine ownership edit), every commenter — including any GitHub user who opened a PR from a fork — is treated as authorized and can run the credential-bearing integration job on their own PR's code.

The current CODEOWNERS (`* @prachib29 @ronakgadia`) has no team entry, so the bypass is dormant today, but the logic is already wrong and activates on the first team-style entry.

Reported through the Google Open Source Software VRP; opening this fix per the triage suggestion to patch directly with maintainers.

### Fix

Authorize a commenter only if they are named directly in CODEOWNERS, or are an **active member** of a CODEOWNERS team in this org, checked via `github.rest.teams.getMembershipForUserInOrg` against the commenter. The team lookup fails closed (404 / missing org-read scope → unauthorized).

### Notes

- No functional change for the current CODEOWNERS (named owners keep working).
- Team-based authorization needs the `check-authorization` job's `GITHUB_TOKEN` to be able to read org team membership; if it cannot, those lookups fail closed and named ownership still applies.
